### PR TITLE
feat(providers): add Z.ai (GLM-5.2) and Sakana (Fugu) providers

### DIFF
--- a/agent_core/core/impl/llm/errors.py
+++ b/agent_core/core/impl/llm/errors.py
@@ -110,6 +110,8 @@ _PROVIDER_DISPLAY: Dict[str, str] = {
     "byteplus": "BytePlus",
     "deepseek": "DeepSeek",
     "grok": "Grok",
+    "glm": "Z.ai (GLM)",
+    "fugu": "Sakana (Fugu)",
     "moonshot": "Moonshot",
     "minimax": "MiniMax",
     "remote": "Ollama",

--- a/agent_core/core/impl/llm/interface.py
+++ b/agent_core/core/impl/llm/interface.py
@@ -504,6 +504,8 @@ class LLMInterface:
                 "moonshot",
                 "grok",
                 "openrouter",
+                "glm",
+                "fugu",
             ):
                 response = self._generate_openai(system_prompt, user_prompt)
             elif self.provider == "remote":
@@ -678,7 +680,7 @@ class LLMInterface:
             (self.provider == "byteplus" and self._byteplus_cache_manager)
             or (self.provider == "gemini" and self._gemini_cache_manager)
             or (
-                self.provider in ("openai", "deepseek", "grok", "openrouter")
+                self.provider in ("openai", "deepseek", "grok", "openrouter", "glm", "fugu")
                 and self.client
             )  # OpenAI/DeepSeek/Grok/OpenRouter use automatic caching with prompt_cache_key (and cache_control for Anthropic-routed OpenRouter models)
             or (
@@ -805,7 +807,7 @@ class LLMInterface:
             if self.provider == "gemini" and self._gemini_cache_manager:
                 return True
             if (
-                self.provider in ("openai", "deepseek", "grok", "openrouter")
+                self.provider in ("openai", "deepseek", "grok", "openrouter", "glm", "fugu")
                 and self.client
             ):
                 return True
@@ -928,7 +930,7 @@ class LLMInterface:
             return cleaned
 
         # Handle OpenAI/DeepSeek/Grok/OpenRouter with call_type-based cache routing
-        if self.provider in ("openai", "deepseek", "grok", "openrouter"):
+        if self.provider in ("openai", "deepseek", "grok", "openrouter", "glm", "fugu"):
             # Get stored system prompt or use provided one
             session_key = f"{task_id}:{call_type}"
             stored_system_prompt = self._session_system_prompts.get(session_key)

--- a/agent_core/core/impl/settings/manager.py
+++ b/agent_core/core/impl/settings/manager.py
@@ -35,6 +35,8 @@ DEFAULT_SETTINGS = {
         "minimax": "",
         "deepseek": "",
         "moonshot": "",
+        "glm": "",
+        "fugu": "",
     },
     "endpoints": {
         "remote_model_url": "",

--- a/agent_core/core/impl/vlm/interface.py
+++ b/agent_core/core/impl/vlm/interface.py
@@ -272,7 +272,7 @@ class VLMInterface:
                 raise RuntimeError(
                     "DeepSeek does not support vision/VLM. Use a different provider for image description."
                 )
-            elif self.provider in ("openai", "minimax", "moonshot", "grok"):
+            elif self.provider in ("openai", "minimax", "moonshot", "grok", "glm"):
                 response = self._openai_describe_bytes(
                     image_bytes, system_prompt, user_prompt, json_mode=json_mode
                 )

--- a/agent_core/core/models/connection_tester.py
+++ b/agent_core/core/models/connection_tester.py
@@ -72,6 +72,12 @@ def test_provider_connection(
         elif provider == "deepseek":
             url = cfg.default_base_url
             return _test_openai_compat(provider, api_key, url, timeout, model)
+        elif provider == "glm":
+            url = cfg.default_base_url
+            return _test_openai_compat(provider, api_key, url, timeout, model)
+        elif provider == "fugu":
+            url = cfg.default_base_url
+            return _test_openai_compat(provider, api_key, url, timeout, model)
         elif provider in ("moonshot", "minimax"):
             return _test_moonshot_minimax(
                 provider, api_key, cfg.default_base_url, timeout, model
@@ -245,6 +251,8 @@ _DISPLAY = {
     "moonshot": "Moonshot",
     "minimax": "MiniMax",
     "grok": "Grok (xAI)",
+    "glm": "Z.ai (GLM)",
+    "fugu": "Sakana (Fugu)",
     "openrouter": "OpenRouter",
     "remote": "Ollama",
     "bedrock": "AWS Bedrock",

--- a/agent_core/core/models/factory.py
+++ b/agent_core/core/models/factory.py
@@ -121,7 +121,7 @@ class ModelFactory:
             Dictionary with provider context including client instances
         """
         # OpenAI-compatible providers that use OpenAI client with a custom base_url
-        _OPENAI_COMPAT = {"minimax", "deepseek", "moonshot", "grok", "openrouter"}
+        _OPENAI_COMPAT = {"minimax", "deepseek", "moonshot", "grok", "openrouter", "glm", "fugu"}
 
         if provider not in PROVIDER_CONFIG:
             raise ValueError(f"Unsupported provider: {provider}")

--- a/agent_core/core/models/model_registry.py
+++ b/agent_core/core/models/model_registry.py
@@ -70,6 +70,23 @@ MODEL_REGISTRY = {
         InterfaceType.IMAGE_GEN: None,
         InterfaceType.VIDEO_GEN: None,
     },
+    "glm": {
+        # Z.ai (Zhipu AI) GLM-5.2 -- 1M-context, OpenAI-compatible, multimodal.
+        InterfaceType.LLM: "glm-5.2",
+        InterfaceType.VLM: "glm-5.2",
+        InterfaceType.EMBEDDING: None,
+        InterfaceType.IMAGE_GEN: None,
+        InterfaceType.VIDEO_GEN: None,
+    },
+    "fugu": {
+        # Sakana AI Fugu -- OpenAI-compatible orchestration model. Text/LLM
+        # only here; no native vision/embedding/image/video models exposed.
+        InterfaceType.LLM: "fugu",
+        InterfaceType.VLM: None,
+        InterfaceType.EMBEDDING: None,
+        InterfaceType.IMAGE_GEN: None,
+        InterfaceType.VIDEO_GEN: None,
+    },
     "openrouter": {
         # OpenRouter slugs follow `<provider>/<model>` format. Default to a Claude
         # model so KV caching exercises the cache_control path on first use.

--- a/agent_core/core/models/provider_config.py
+++ b/agent_core/core/models/provider_config.py
@@ -41,6 +41,16 @@ PROVIDER_CONFIG = {
         api_key_env="XAI_API_KEY",
         default_base_url="https://api.x.ai/v1",
     ),
+    "glm": ProviderConfig(
+        # Z.ai (Zhipu AI) GLM models -- OpenAI-compatible API.
+        api_key_env="ZAI_API_KEY",
+        default_base_url="https://api.z.ai/api/paas/v4",
+    ),
+    "fugu": ProviderConfig(
+        # Sakana AI Fugu -- OpenAI-compatible API.
+        api_key_env="SAKANA_API_KEY",
+        default_base_url="https://api.sakana.ai/v1",
+    ),
     "openrouter": ProviderConfig(
         api_key_env="OPENROUTER_API_KEY",
         base_url_env="OPENROUTER_BASE_URL",

--- a/app/config/connection_test_models.json
+++ b/app/config/connection_test_models.json
@@ -22,6 +22,12 @@
     "moonshot": {
         "model": "kimi-k2.5"
     },
+    "glm": {
+        "model": "glm-5.2"
+    },
+    "fugu": {
+        "model": "fugu"
+    },
     "remote": {
         "model": "llama3"
     },

--- a/app/onboarding/interfaces/steps.py
+++ b/app/onboarding/interfaces/steps.py
@@ -117,6 +117,8 @@ class ProviderStep:
         ("minimax", "MiniMax", "MiniMax models"),
         ("moonshot", "Moonshot", "Moonshot models"),
         ("grok", "Grok (xAI)", "Grok models"),
+        ("glm", "Z.ai (GLM)", "GLM models"),
+        ("fugu", "Sakana (Fugu)", "Fugu models"),
         ("remote", "Ollama (Local)", "Self-hosted models"),
     ]
 
@@ -163,6 +165,8 @@ class ApiKeyStep:
         "minimax": "MINIMAX_API_KEY",
         "moonshot": "MOONSHOT_API_KEY",
         "grok": "XAI_API_KEY",
+        "glm": "ZAI_API_KEY",
+        "fugu": "SAKANA_API_KEY",
         "remote": None,  # Ollama uses a base URL, not an API key
     }
 

--- a/app/ui_layer/commands/builtin/provider.py
+++ b/app/ui_layer/commands/builtin/provider.py
@@ -22,6 +22,8 @@ class ProviderCommand(Command):
         "byteplus": ("BYTEPLUS_API_KEY", "BytePlus"),
         "deepseek": ("DEEPSEEK_API_KEY", "DeepSeek"),
         "grok": ("XAI_API_KEY", "Grok (xAI)"),
+        "glm": ("ZAI_API_KEY", "Z.ai (GLM)"),
+        "fugu": ("SAKANA_API_KEY", "Sakana (Fugu)"),
         "openrouter": ("OPENROUTER_API_KEY", "OpenRouter"),
         "remote": (None, "Ollama (Local)"),
     }
@@ -54,6 +56,8 @@ Providers:
   byteplus   - BytePlus Kimi models
   deepseek   - DeepSeek models
   grok       - Grok (xAI) models
+  glm        - Z.ai (GLM) models
+  fugu       - Sakana (Fugu) models
   openrouter - OpenRouter (300+ models, one key)
   remote     - Ollama (local models)
 

--- a/app/ui_layer/settings/model_settings.py
+++ b/app/ui_layer/settings/model_settings.py
@@ -72,6 +72,18 @@ PROVIDER_INFO = {
         "settings_key": "grok",
         "requires_api_key": True,
     },
+    "glm": {
+        "name": "Z.ai (GLM)",
+        "api_key_env": "ZAI_API_KEY",
+        "settings_key": "glm",
+        "requires_api_key": True,
+    },
+    "fugu": {
+        "name": "Sakana (Fugu)",
+        "api_key_env": "SAKANA_API_KEY",
+        "settings_key": "fugu",
+        "requires_api_key": True,
+    },
     "openrouter": {
         "name": "OpenRouter",
         "api_key_env": "OPENROUTER_API_KEY",

--- a/app/ui_layer/settings/provider_settings.py
+++ b/app/ui_layer/settings/provider_settings.py
@@ -21,6 +21,8 @@ PROVIDER_TO_SETTINGS_KEY = {
     "minimax": "minimax",
     "moonshot": "moonshot",
     "grok": "grok",
+    "glm": "glm",
+    "fugu": "fugu",
     "openrouter": "openrouter",
     # Bedrock has no single API key — credentials live under "aws_credentials"
     # in settings.json (handled separately from the api_keys map). The entry


### PR DESCRIPTION
Both are OpenAI-compatible and route through the existing OpenAI-compatible client path. They appear automatically in the Settings model selector (the provider list is backend-driven from PROVIDER_INFO).

- GLM (Z.ai): glm-5.2 (LLM+VLM), key ZAI_API_KEY, base https://api.z.ai/api/paas/v4
- Fugu (Sakana): fugu (LLM), key SAKANA_API_KEY, base https://api.sakana.ai/v1

Registered across model_registry, provider_config, factory (_OPENAI_COMPAT), llm/vlm interface routing, error display name, connection tester + test models, PROVIDER_INFO, onboarding steps, provider_settings, and the /provider command.