### PR TITLE
Ai Enhance Fix

### DIFF
--- a/agent_core/core/prompts/reasoning.py
+++ b/agent_core/core/prompts/reasoning.py
@@ -60,6 +60,11 @@ actual noun it refers to, using context from the conversation if available.
 RULE 7 — ONE ACTION FRAME
 Do not chain unrelated actions into one prompt. If the user asked for one
 thing, keep it as one thing. Do not add "and also..." unless the user said so.
+
+RULE 8 - PRESERVE INITIAL LANGUAGE
+If the user wrote their message in another language, only enhance in the detected
+language. Never stray or use another language other than what the user has written in
+unless the user said so.
 </rules>
 
 <reasoning_protocol>
@@ -70,6 +75,7 @@ Before writing the enhanced prompt, silently work through:
 4. simple or complex task? (single-shot vs. multi-step + verify)
 5. Any scheduling signal? (one-time vs. recurring)
 6. Any pronouns to replace with actual nouns?
+7. What is the intended language?
 </reasoning_protocol>
 
 <anti_patterns>
@@ -81,6 +87,7 @@ NEVER do these:
 - Do NOT exceed 4 sentences
 - Do NOT use passive voice — use active imperative verbs
 - Do NOT leave platform names implicit when a platform is involved
+- Do NOT start using another language other than the one written in by the user initially unless asked for by the user
 </anti_patterns>
 
 <output_format>

--- a/app/ui_layer/browser/frontend/src/components/Chat/Chat.module.css
+++ b/app/ui_layer/browser/frontend/src/components/Chat/Chat.module.css
@@ -429,6 +429,12 @@
   outline: none;
 }
 
+.input:disabled {
+  color: var(--text-muted);
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 .input::placeholder {
   color: var(--text-muted);
 }

--- a/app/ui_layer/browser/frontend/src/components/Chat/Chat.module.css
+++ b/app/ui_layer/browser/frontend/src/components/Chat/Chat.module.css
@@ -596,6 +596,11 @@
   color: var(--color-error, #ef4444);
 }
 
+.micCombo:disabled {
+  color: var(--text-muted);
+  cursor: not-allowed;
+}
+
 .micIconWrap {
   position: relative;
   display: flex;

--- a/app/ui_layer/browser/frontend/src/components/Chat/Chat.tsx
+++ b/app/ui_layer/browser/frontend/src/components/Chat/Chat.tsx
@@ -796,9 +796,9 @@ export function Chat({ sessionId, placeholder }: ChatProps) {
   //enhance button's display state
   useEffect(() => {
     if (input.trim() !== '') return
-    if (enhancing) setEnhancing(false)
-    if (plusOpen) setPlusOpen (false)
-  },[input, enhancing, plusOpen]
+    setEnhancing(false)
+    setPlusOpen (false)
+  },[input]
   )
 
   // Reset enhancing spinner if the WebSocket disconnects mid-request

--- a/app/ui_layer/browser/frontend/src/components/Chat/Chat.tsx
+++ b/app/ui_layer/browser/frontend/src/components/Chat/Chat.tsx
@@ -84,6 +84,7 @@ interface SuggestedPlaybook {
 }
 
 const SUGGESTED_PLAYBOOK_COUNT = 3
+const ENHANCE_TIMEOUT_MS = 30000
 
 // Chat-delivery actions — the ones whose visible form IS a chat bubble in
 // this interface. A chunk whose only actions are these renders nothing at
@@ -321,6 +322,22 @@ export function Chat({ sessionId, placeholder }: ChatProps) {
   }, [dispatch, sessionId])
 
   const [enhancing, setEnhancing] = useState(false)
+  // Guards against the user waiting forever if the enhance WS response
+  // never comes back. Cleared (never fires) on success, disconnect, or the
+  // draft being emptied — see the effects/handler below.
+  const enhanceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Single choke point for turning enhancing off: always cancels the
+  // timeout alongside it, so success/disconnect/clear-draft paths can't
+  // leave a stale timer that fires 30s later on an already-finished request.
+  const stopEnhancing = useCallback(() => {
+    if (enhanceTimeoutRef.current !== null) {
+      clearTimeout(enhanceTimeoutRef.current)
+      enhanceTimeoutRef.current = null
+    }
+    setEnhancing(false)
+  }, [])
+
   // Reply-to-bubble: set from an agent bubble's hover Reply action. The
   // next send carries the quoted original so the event stream records
   // which message the user replied to. No routing — session is explicit.
@@ -782,35 +799,46 @@ export function Chat({ sessionId, placeholder }: ChatProps) {
     if (enhancedPrompt === null) return
     if (input.trim() === ''){
       //Is the box cleared? Do not repopulate the deleted text box.
-      setEnhancing(false)
+      stopEnhancing()
       clearEnhancedPrompt()
       return
     }
     setInput(enhancedPrompt)
-    setEnhancing(false)
+    stopEnhancing()
     clearEnhancedPrompt()
     inputRef.current?.focus()
-  }, [enhancedPrompt, clearEnhancedPrompt, setInput, input])
+  }, [enhancedPrompt, clearEnhancedPrompt, setInput, input, stopEnhancing])
 
   // Deleting the draft cancels any in-flight/pending enhance and resets the
   //enhance button's display state
   useEffect(() => {
     if (input.trim() !== '') return
-    setEnhancing(false)
+    stopEnhancing()
     setPlusOpen (false)
-  },[input]
+  },[input, stopEnhancing]
   )
 
   // Reset enhancing spinner if the WebSocket disconnects mid-request
   useEffect(() => {
-    if (!connected) setEnhancing(false)
-  }, [connected])
+    if (!connected) stopEnhancing()
+  }, [connected, stopEnhancing])
 
   const handleEnhancePrompt = useCallback(() => {
     if (!input.trim() || enhancing) return
     setEnhancing(true)
     enhancePrompt(input.trim())
-  }, [input, enhancing, enhancePrompt])
+    enhanceTimeoutRef.current = setTimeout(() => {
+    enhanceTimeoutRef.current = null
+    setEnhancing(false)
+    showToast('error', 'AI enhance timed out — please try again.')
+  }, ENHANCE_TIMEOUT_MS)
+  }, [input, enhancing, enhancePrompt, showToast])
+
+  useEffect(() => {
+  return () => {
+    if (enhanceTimeoutRef.current !== null) clearTimeout(enhanceTimeoutRef.current)
+  }
+}, [])
 
   const handleOptionClick = useCallback((value: string, messageId: string) => {
     if (value === 'open_settings_model') {
@@ -1446,6 +1474,7 @@ export function Chat({ sessionId, placeholder }: ChatProps) {
                   className={`${styles.micCombo}${isListening ? ` ${styles.micComboActive}` : ''}`}
                   title={isListening ? 'Stop listening' : 'Voice input'}
                   onClick={toggleListening}
+                  disabled = {enhancing}
                 >
                   <span className={styles.micIconWrap}>
                     {isListening ? <MicOff size={18} /> : <Mic size={18} />}
@@ -1493,7 +1522,7 @@ export function Chat({ sessionId, placeholder }: ChatProps) {
                   type="button"
                   className={styles.sendBtn}
                   onClick={handleSend}
-                  disabled={(!input.trim() && pendingAttachments.length === 0) || !attachmentValidation.valid}
+                  disabled={(!input.trim() && pendingAttachments.length === 0) || !attachmentValidation.valid || enhancing}
                   title="Send"
                   aria-label="Send message"
                 >

--- a/app/ui_layer/browser/frontend/src/components/Chat/Chat.tsx
+++ b/app/ui_layer/browser/frontend/src/components/Chat/Chat.tsx
@@ -1412,7 +1412,9 @@ export function Chat({ sessionId, placeholder }: ChatProps) {
                 aria-label="Attach and tools"
                 aria-expanded={plusOpen}
               >
-                <Plus size={18} />
+                {enhancing
+                   ? <Loader2 size={18} className={styles.uploadingSpinner} />
+                   : <Plus size={18} />}
               </button>
               {plusOpen && (
                 <div className={styles.plusMenu}>

--- a/app/ui_layer/browser/frontend/src/components/Chat/Chat.tsx
+++ b/app/ui_layer/browser/frontend/src/components/Chat/Chat.tsx
@@ -806,7 +806,10 @@ export function Chat({ sessionId, placeholder }: ChatProps) {
     setInput(enhancedPrompt)
     stopEnhancing()
     clearEnhancedPrompt()
-    inputRef.current?.focus()
+    // Defer focus: the textarea is still disabled in the DOM this tick
+    // (enhancing→false hasn't re-rendered yet), so a synchronous focus()
+    // would be ignored.
+    setTimeout(() => inputRef.current?.focus(), 0)
   }, [enhancedPrompt, clearEnhancedPrompt, setInput, input, stopEnhancing])
 
   // Deleting the draft cancels any in-flight/pending enhance and resets the
@@ -1428,6 +1431,7 @@ export function Chat({ sessionId, placeholder }: ChatProps) {
             rows={1}
             lang={micLang}
             inputMode="text"
+            disabled={enhancing}
           />
 
           <div className={styles.inputControls}>

--- a/app/ui_layer/browser/frontend/src/components/Chat/Chat.tsx
+++ b/app/ui_layer/browser/frontend/src/components/Chat/Chat.tsx
@@ -780,11 +780,26 @@ export function Chat({ sessionId, placeholder }: ChatProps) {
   // Consume enhanced prompt from context when WS response arrives
   useEffect(() => {
     if (enhancedPrompt === null) return
+    if (input.trim() === ''){
+      //Is the box cleared? Do not repopulate the deleted text box.
+      setEnhancing(false)
+      clearEnhancedPrompt()
+      return
+    }
     setInput(enhancedPrompt)
     setEnhancing(false)
     clearEnhancedPrompt()
     inputRef.current?.focus()
-  }, [enhancedPrompt, clearEnhancedPrompt, setInput])
+  }, [enhancedPrompt, clearEnhancedPrompt, setInput, input])
+
+  // Deleting the draft cancels any in-flight/pending enhance and resets the
+  //enhance button's display state
+  useEffect(() => {
+    if (input.trim() !== '') return
+    if (enhancing) setEnhancing(false)
+    if (plusOpen) setPlusOpen (false)
+  },[input, enhancing, plusOpen]
+  )
 
   // Reset enhancing spinner if the WebSocket disconnects mid-request
   useEffect(() => {


### PR DESCRIPTION
**What:**

- [X] Ai enhance sometimes switches back to english instead of the language typed in by the user.
-  [x] The ai enhance continues even when the message has been deleted in the chat box. This can lead to enhancing continuing until the page is refreshed.

Update to what:
- [x] Add spinner button instead of plus to show user that it is in the process of enhancing
- [x] Disable the SEND and DICTATE button so that the user can't change the message apart from editing and deleting.
- [x] There needs to be a timeout (30 seconds?) for ONLY the ai enhancement so the user isn't stuck waiting.

**Why the changes:**
- Added in a new rule for the agent to follow to stick to the language written in by the user unless asked not to. Added more guidelines around that to not switch back to english or deviate from language written in unless otherwise stated.
- If the input changes to being empty, stop enhancing, do not repopulate the textbox with the enhanced answer, and reset the enhance buttons to their idle state.
- The plus turns into a spinner to show the user that it is being enhanced rather than them having to open up the plus menu
- The user is unable to send or dictate their message during enhancing as the buttons are disabled. I added the same no entry symbol to the mic to fit in with the send button and give more of a visual clue to the user
- A timeout occurs 30 seconds from enhancing and notifies the user if the enhancing is taking too long. I haven't yet tested that yet however. I have no idea if the error message will look right.
