### PR TITLE
fix: don't flag an in-flight parallel duplicate as crashed

### DIFF
--- a/app/triggers/activity_log.py
+++ b/app/triggers/activity_log.py
@@ -240,6 +240,10 @@ class ActivityLogGuard:
 
     def __init__(self, log: ActivityLog):
         self._log = log
+        # idem_keys with an INTENT this process recorded and hasn't yet
+        # complete()'d, so begin() can tell a live batch mate apart from a
+        # crash-then-restart, which a fresh empty set never carries.
+        self._in_flight: set[str] = set()
 
     def begin(
         self,
@@ -254,6 +258,7 @@ class ActivityLogGuard:
             # Fresh attempt, or deliberate retake after a failed/uncertain
             # run — record intent BEFORE the side effect.
             self._log.record_intent(idem_key, action_name, session_id)
+            self._in_flight.add(idem_key)
             return GuardDecision(proceed=True, idem_key=idem_key)
 
         if row["status"] == STATUS_DONE:
@@ -265,6 +270,7 @@ class ActivityLogGuard:
                 done_at = 0.0
             if time.time() - done_at > DONE_DEDUP_WINDOW_SECONDS:
                 self._log.record_intent(idem_key, action_name, session_id)
+                self._in_flight.add(idem_key)
                 return GuardDecision(proceed=True, idem_key=idem_key)
             # This exact side effect just completed — return its stored
             # output instead of doing it again.
@@ -280,6 +286,23 @@ class ActivityLogGuard:
             )
             logger.info(f"[ActivityLog] Skipped duplicate {action_name} ({idem_key})")
             return GuardDecision(proceed=False, idem_key=idem_key, stored_output=stored)
+
+        if idem_key in self._in_flight:
+            # A batch mate is still executing this exact call, not crashed;
+            # refuse without touching the row so it can record the outcome.
+            logger.info(
+                f"[ActivityLog] {action_name} ({idem_key}) already in "
+                f"flight in this batch, refusing the duplicate"
+            )
+            return GuardDecision(
+                proceed=False,
+                idem_key=idem_key,
+                note=(
+                    f"{action_name} is already running with these exact "
+                    f"inputs. Wait for it to finish instead of calling it "
+                    f"again."
+                ),
+            )
 
         # Stale INTENT: a previous attempt was interrupted between starting
         # the side effect and recording its outcome. Surface once; the next
@@ -306,6 +329,7 @@ class ActivityLogGuard:
         status: str,
         outputs: Optional[Dict[str, Any]],
     ) -> None:
+        self._in_flight.discard(idem_key)
         ledger_status = STATUS_DONE if status == "success" else STATUS_FAILED
 
         provider_ref = None

--- a/tests/test_activity_log.py
+++ b/tests/test_activity_log.py
@@ -78,6 +78,31 @@ class TestGuardLifecycle:
         assert d3.proceed
         assert log2.get(d1.idem_key)["status"] == "INTENT"
 
+    def test_parallel_duplicate_in_same_process_is_not_flagged_as_crashed(
+        self, tmp_path
+    ):
+        log, guard = make_guard(tmp_path)
+        d1 = guard.begin("send_gmail", INPUTS, "task1")
+        assert d1.proceed
+        # A batch mate with identical inputs, dispatched by execute_parallel
+        # before d1's complete() is reached: not a crash, still running.
+        d2 = guard.begin("send_gmail", INPUTS, "task1")
+        assert not d2.proceed
+        assert d2.stored_output is None
+        assert "MAY" not in d2.note
+        assert "already running" in d2.note
+        assert log.get(d1.idem_key)["status"] == "INTENT"
+
+        guard.complete(
+            d1.idem_key, "success", {"status": "success", "message_id": "msg-1"}
+        )
+
+        # Once complete()'d, a later identical call follows the ordinary
+        # DONE-dedup path, not the in-flight one.
+        d3 = guard.begin("send_gmail", INPUTS, "task1")
+        assert not d3.proceed
+        assert d3.stored_output["_idempotent_replay"] is True
+
     def test_failed_run_can_be_retried(self, tmp_path):
         log, guard = make_guard(tmp_path)
         d1 = guard.begin("send_gmail", INPUTS, "task1")


### PR DESCRIPTION
## What
- `ActivityLogGuard` now tracks idem_keys with an INTENT it recorded but hasn't `complete()`'d yet.
- `begin()`'s stale-INTENT branch checks that set before treating a row as a crashed prior attempt.

## Why
`execute_parallel` dispatches every call in a batch before any of them completes, so two identical irreversible calls land two `begin()` calls back to back with no `complete()` in between. The second call saw the first's INTENT row and treated it as an interrupted (crashed) attempt, downgrading it to FAILED and telling the LLM the action "may have already happened," even though the first call was still genuinely running. Repro and details in #442.

Closes #442

Age alone can't fix this: an immediate crash-then-restart produces the exact same young INTENT row, and that case still needs the "may have happened" warning (there's a test for it). Tracking in-flight keys per guard instance handles both correctly, since a restart creates a fresh guard with an empty set.

## How to test
- `python3 -m pytest tests/test_activity_log.py -q`: 12 passed. The new test fails on `dev` and passes on this branch.
- `python3 -m pytest tests -q` (skipping `tests/e2e`, `tests/llm/golden`, and two other files with pre-existing collection errors unrelated to this change, missing `mss`, a relative import bug): 944 passed, 29 skipped, 0 failed.
- `ruff format --check` and `ruff check` clean on both changed files.
- `python -m compileall -q app agent_core agents decorators skills`

One thing I didn't add a fallback for: if something throws between `begin()` and `complete()` and `complete()` never runs, that idem_key stays in the in-flight set until the process restarts, so a genuinely stuck duplicate would keep reading as "already running" instead of eventually getting flagged as a possible crash. The ledger row was already stuck at INTENT in that same case before this change, so it's not a new risk, just not one this closes.

## Screenshots / Logs
Not UI-facing.