### PR TITLE
Prevent free-text submission during IME composition in question box

### DIFF
--- a/app/ui_layer/browser/frontend/src/components/Chat/QuestionBox.tsx
+++ b/app/ui_layer/browser/frontend/src/components/Chat/QuestionBox.tsx
@@ -89,7 +89,11 @@ export function QuestionBox({ question, queueTotal, onAnswer, onDismiss }: Quest
             value={text}
             onChange={e => setText(e.target.value)}
             onKeyDown={e => {
-              if (e.key === 'Enter') {
+              if (
+                e.key === 'Enter' &&
+                !e.shiftKey &&
+                !e.nativeEvent.isComposing
+              ) {
                 e.preventDefault()
                 submit(text)
               }


### PR DESCRIPTION
## What
- Add IME composition and Shift key checks to the Enter handler in the QuestionBox free-text input.

## Why
Prevent answers from being submitted accidentally when pressing Enter to confirm Japanese IME conversion.

Related to #165.

## How to test
- [ ] Type Japanese text in the question's free-text input and press Enter to confirm conversion. Verify that the answer is not submitted.
- [ ] Press Enter again after conversion is complete. Verify that the answer is submitted.
- [ ] Press Shift+Enter. Verify that the answer is not submitted.
- [ ] Click the send button. Verify that the answer is submitted normally.
